### PR TITLE
move blocks to standard path

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -92,11 +92,6 @@ cmf_routing:
 knp_menu:
     twig: true
 
-cmf_block:
-    persistence:
-        phpcr:
-            block_basepath: /cms/blocks
-
 sonata_block:
     default_contexts: [cms]
 

--- a/src/Acme/DemoBundle/DataFixtures/PHPCR/LoadDemoData.php
+++ b/src/Acme/DemoBundle/DataFixtures/PHPCR/LoadDemoData.php
@@ -2,10 +2,11 @@
 
 namespace Acme\DemoBundle\DataFixtures\PHPCR;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Nelmio\Alice\Fixtures;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
+use PHPCR\Util\NodeHelper;
 use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode;
 
 /**
@@ -16,7 +17,7 @@ class LoadDemoData implements FixtureInterface
     /**
      * Load data fixtures with the passed DocumentManager
      *
-     * @param ObjectManager $manager
+     * @param DocumentManager $manager
      */
     public function load(ObjectManager $manager)
     {
@@ -38,6 +39,7 @@ class LoadDemoData implements FixtureInterface
         Fixtures::load(array(__DIR__.'/../../Resources/data/pages.yml'), $manager);
 
         // load the blocks
+        NodeHelper::createPath($manager->getPhpcrSession(), '/cms/content/blocks');
         Fixtures::load(array(__DIR__.'/../../Resources/data/blocks.yml'), $manager);
 
         // save the changes

--- a/src/Acme/DemoBundle/Resources/data/blocks.yml
+++ b/src/Acme/DemoBundle/Resources/data/blocks.yml
@@ -1,22 +1,22 @@
 Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ContainerBlock:
     hero_unit:
-        id: /cms/blocks/hero_unit
+        id: /cms/content/blocks/hero_unit
 
 Acme\DemoBundle\Document\UnitBlock:
     read_quick_tour:
-        id: /cms/blocks/hero_unit/quick_tour
+        id: /cms/content/blocks/hero_unit/quick_tour
         text: Read the Quick Tour
         url: http://symfony.com/doc/current/cmf/quick_tour/the_big_picture.html
         image: bundles/acmedemo/images/welcome-quick-tour.gif
 
     configure:
-        id: /cms/blocks/hero_unit/configure
+        id: /cms/content/blocks/hero_unit/configure
         text: Configure
         route: _configurator_home
         image: bundles/acmedemo/images/welcome-configure.gif
 
     demo:
-        id: /cms/blocks/hero_unit/demo
+        id: /cms/content/blocks/hero_unit/demo
         text: View the demo
         route: /cms/simple/demo
         image: bundles/acmedemo/images/welcome-demo.gif

--- a/src/Acme/DemoBundle/Resources/views/home.html.twig
+++ b/src/Acme/DemoBundle/Resources/views/home.html.twig
@@ -7,6 +7,6 @@
 
 {% block main %}
     <div class="row">
-    {{ sonata_block_render({'name': '/cms/blocks/hero_unit'}) }}
+    {{ sonata_block_render({'name': '/cms/content/blocks/hero_unit'}) }}
     </div>
 {% endblock %}


### PR DESCRIPTION
we should have the blocks in the standard location inside content. otherwise when people add sonata admin and want to add blocks to content documents, they will run into problems.
