### PR TITLE
Import AcmeDemoBundle for dev-environment only

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -1,7 +1,6 @@
 imports:
     - { resource: parameters.yml }
     - { resource: security.yml }
-    - { resource: @AcmeDemoBundle/Resources/config/services.yml }
 
 framework:
     #esi:             ~

--- a/src/Acme/DemoBundle/DependencyInjection/AcmeDemoExtension.php
+++ b/src/Acme/DemoBundle/DependencyInjection/AcmeDemoExtension.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Acme\DemoBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Config\FileLocator;
+
+class AcmeDemoExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}


### PR DESCRIPTION
The `AcmeDemoBundle` is dev-only (see `AppKernel`) and therefore not available in prod
